### PR TITLE
Replace quote chars with words in package summary

### DIFF
--- a/python-switch-quotes.el
+++ b/python-switch-quotes.el
@@ -1,4 +1,4 @@
-;;; python-switch-quotes.el --- cycle between ' and " quotes in python strings
+;;; python-switch-quotes.el --- cycle between single and double quotes in python strings
 ;;; Copyright (C) 2016 Vladimir Lagunov
 
 ;;; Author: Vladimir Lagunov <lagunov.vladimir@gmail.com>


### PR DESCRIPTION
Use the words "single" and "double" instead of the literal quote characters in the package summary. This is to prevent the unbalanced double quote from messing up the font locking of the package menu buffer.